### PR TITLE
chore: Optimize breakpoint registration logic

### DIFF
--- a/app/components/HeaderNavbar.vue
+++ b/app/components/HeaderNavbar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import {useSelfUserStore} from "~/stores/useSelfUser";
 import {useAppConfigStore} from "~/stores/useAppConfig";
-import {isDesktop, isTablet, watchBreakpoint} from "~/utils/browser";
+import {isDesktop, isTablet} from "~/utils/browser";
 import ModalSelectProfile from "~/components/Modal/ModalSelectProfile.vue";
 import type {DropdownMenuItem} from "#ui/components/DropdownMenu";
 import {Permission} from "~/types/api/permissions";
@@ -97,14 +97,6 @@ const overlay = useOverlay()
     ]);
   }
 
-  onMounted(() => {
-    watchBreakpoint()
-    window.addEventListener('resize', watchBreakpoint)
-  })
-
-  onBeforeUnmount(() => {
-    window.removeEventListener('resize', watchBreakpoint)
-  })
 </script>
 
 <template>

--- a/app/pages/login/password-reset.vue
+++ b/app/pages/login/password-reset.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type {FormError, TabsItem} from '#ui/types'
 import UserQuery from "~/composables/api/query/UserQuery";
-import {isMobile, watchBreakpoint} from "~/utils/browser";
+import {isMobile} from "~/utils/browser";
 import type {NuxtTurnstile} from "#components";
 
 const toast = useToast()
@@ -107,14 +107,6 @@ async function initiatePasswordReset() {
   securityEmailSent.value = true
 }
 
-onMounted(() => {
-  watchBreakpoint()
-  window.addEventListener('resize', watchBreakpoint)
-})
-
-onBeforeUnmount(() => {
-  window.removeEventListener('resize', watchBreakpoint)
-})
 </script>
 
 <template>

--- a/app/pages/login/register.vue
+++ b/app/pages/login/register.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type {FormError, SelectItem, SelectMenuItem, TabsItem} from '#ui/types'
 import UserQuery from "~/composables/api/query/UserQuery";
-import {isMobile, watchBreakpoint} from "~/utils/browser";
+import {isMobile} from "~/utils/browser";
 import type {NuxtTurnstile} from "#components";
 import {useLoginUser} from "~/composables/api/api";
 import {ClubActivity, getSelectMenuClubActivity} from "~/types/api/item/club";
@@ -180,14 +180,6 @@ async function initiateRegister() {
   securityEmailSent.value = true
 }
 
-onMounted(() => {
-  watchBreakpoint()
-  window.addEventListener('resize', watchBreakpoint)
-})
-
-onBeforeUnmount(() => {
-  window.removeEventListener('resize', watchBreakpoint)
-})
 </script>
 
 <template>

--- a/app/plugins/breakpoint.client.ts
+++ b/app/plugins/breakpoint.client.ts
@@ -1,0 +1,6 @@
+import {watchBreakpoint} from "~/utils/browser";
+
+export default defineNuxtPlugin(() => {
+  watchBreakpoint()
+  window.addEventListener('resize', watchBreakpoint)
+})

--- a/app/utils/browser.ts
+++ b/app/utils/browser.ts
@@ -60,15 +60,15 @@ export function isTouchDevice() {
 
 export const activeBreakpoint: Ref<string|undefined> = ref(undefined)
 export function watchBreakpoint() {
-  if (window.screen.width >= 1536) {
+  if (window.innerWidth >= 1536) {
     activeBreakpoint.value = '2xl'
-  } else if (window.screen.width >= 1280) {
+  } else if (window.innerWidth >= 1280) {
     activeBreakpoint.value = 'xl'
-  } else if (window.screen.width >= 1024) {
+  } else if (window.innerWidth >= 1024) {
     activeBreakpoint.value = 'lg'
-  } else if (window.screen.width >= 768) {
+  } else if (window.innerWidth >= 768) {
     activeBreakpoint.value = 'md'
-  } else if (window.screen.width >= 640) {
+  } else if (window.innerWidth >= 640) {
     activeBreakpoint.value = 'sm'
   } else {
     activeBreakpoint.value = 'xs'


### PR DESCRIPTION
Browser breakpoint should be a nuxt plugin.

Also fix `Menu` button not showing on resize desktop windows.

BTW, a nuxt plugin do :

  - Runs once at app startup, before any component mounts
  - Has access to the Nuxt app instance (defineNuxtPlugin(() => { ... }))
  - The right place for global side effects that need to be initialized exactly once: event listeners, third-party SDK setup, global error handlers
  - For xxx.ts specifically: the window.addEventListener('storage', ...) needs to be registered once for the lifetime of the app, not per-component mount/unmount cycle