### PR TITLE
Remove cooldown from Dependabot config (default cooldown is now 3 days)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
       interval: "weekly"
       day: "friday"
       time: "03:00"
-    cooldown:
-      default-days: 1
     open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
Removed cooldown setting from Dependabot configuration.